### PR TITLE
Se creó una versión alternativa de catxml-0.1.1.py que hace uso del m…

### DIFF
--- a/Introducción-a-Python-creando-scripts-con-Click/script_05_desmembrando_xml/catxml-0.1.1-getElementsByTagName.py
+++ b/Introducción-a-Python-creando-scripts-con-Click/script_05_desmembrando_xml/catxml-0.1.1-getElementsByTagName.py
@@ -1,0 +1,39 @@
+#!/usr/bin/env python3
+# -*-coding: utf-8 -*-
+
+import click
+from xml.dom import minidom
+
+def printChildren(node, level = 0):
+    for child in node.childNodes:
+        if child.nodeName != "#text":
+            print("\t"*level + "|_" + child.nodeName)
+            printChildren(child, level + 1)
+
+@click.command()
+@click.option("--raw", is_flag=True, help="Imprime el XML en formato crudo")
+@click.option("--node", type=str, help="Imprime el árbol del nodo especificado")
+@click.argument("filepath", type=click.Path(exists=True))
+def catxml(raw, filepath, node):
+    """
+    Despliega el contenido de un XML
+    """
+    if raw:
+        with open(filepath) as stream:
+            for row in stream:
+                print(row, end="")
+    else:
+        dom = minidom.parse(filepath)
+        if node != None:
+            nodes = dom.getElementsByTagName(node)
+            for child in nodes:
+                print(child.nodeName)
+                printChildren(child)
+            pass
+        else:
+            root = dom.childNodes[0]
+            print(root.nodeName)
+            printChildren(root)
+
+if __name__ == '__main__':
+    catxml()


### PR DESCRIPTION
Se creó una versión alternativa de catxml-0.1.1.py que hace uso del método getElementsByTagName del DOM para extraer los nodos de un cierto nombre.

Para mayor referencia pueden consultar los siguientes links:
https://www.w3schools.com/xml/dom_intro.asp
https://www.w3.org/DOM/
https://www.w3.org/TR/2004/REC-DOM-Level-3-Core-20040407/ecma-script-binding.html